### PR TITLE
Replace references to Skype with generic "video conference"

### DIFF
--- a/_policy/event-commission.md
+++ b/_policy/event-commission.md
@@ -185,7 +185,7 @@ participate in regular, quality events.
         FIT strategic and operational plans, events program, as well as other activities being
         undertaken by the various FIT Commissions and Committees.
     3.  The progress of the Event Commission will be a standard agenda item for the FIT Board
-        governance Skype meetings until determined otherwise.
+        governance video conferences until determined otherwise.
 
 11. Financial Operations of the Event Commission
     1.  Membership of the Event Commission is on a volunteer basis for which no fees or remuneration

--- a/_policy/volunteer.md
+++ b/_policy/volunteer.md
@@ -293,9 +293,9 @@ Volunteer commitment is varied in accordance with the position to which the volu
         expenditure by the FIT Board. Further details of costs that are considered suitable for
         reimbursement and associated approval processes and delegations are found in the
         [FIT Financial Management Policy].
-    3.  It is expected that volunteers will conduct meetings/discussions via Skype or other free
-        internet-based communication and that the volunteer will be responsible for their own
-        computer, internet and other communication requirements.
+    3.  It is expected that volunteers will video conference using free internet-based communication
+        and that the volunteer will be responsible for their own computer, internet and other
+        communication requirements.
 
 15. Requirements of National Touch Association (NTA) in relation to FIT Board nominations
     1.  The respective NTA of the Board volunteer is required to confirm that it endorses the

--- a/_position_description/coaching-commission/chair.md
+++ b/_position_description/coaching-commission/chair.md
@@ -53,12 +53,12 @@ Annual activities and time commitment include the following.
 ### Commission meetings
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Meetings with the Sport Development Director
 
--   Skype and face to face
+-   Video conference and face to face
 -   3-6 Meetings per annum of 1-2 hours duration (dependent on agenda).
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/coaching-commission/member.md
+++ b/_position_description/coaching-commission/member.md
@@ -53,7 +53,7 @@ Annual activities and time commitment include the following.
 ### Commission meetings
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/event-commission/chair.md
+++ b/_position_description/event-commission/chair.md
@@ -53,12 +53,12 @@ Annual activities and time commitment include the following.
 ### Commission meetings
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Meetings with the Sport Development Director
 
--   Skype and face to face
+-   Video conference and face to face
 -   3-6 Meetings per annum of 1-2 hours duration (dependent on agenda).
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/referees-commission/chair.md
+++ b/_position_description/referees-commission/chair.md
@@ -57,12 +57,12 @@ Annual activities and time commitment include the following.
 ### Commission meetings
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Meetings with the Sport Development Director
 
--   Skype and face to face
+-   Video conference and face to face
 -   3-6 Meetings per annum of 1-2 hours duration (dependent on agenda).
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/referees-commission/member.md
+++ b/_position_description/referees-commission/member.md
@@ -55,7 +55,7 @@ Annual activities and time commitment include the following.
 ### Commission meetings   
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/secretary-general.md
+++ b/_position_description/secretary-general.md
@@ -73,7 +73,7 @@ Annual activities and time commitment include the following.
 
 ### Board meetings
 
--   11 Board Meetings per annum of 2-3 hours duration (via Skype).
+-   11 Board Meetings per annum of 2-3 hours duration (via video conference).
 -   Preparation time for each Board meeting of 4-6 hours.
 -   One AGM per year in various venues (face to face meeting).
 

--- a/_position_description/womens-commission/chair.md
+++ b/_position_description/womens-commission/chair.md
@@ -54,12 +54,12 @@ Annual activities and time commitment include the following.
 ### Commission meetings
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Meetings with the Sport Development Director
 
--   Skype and face to face
+-   Video conference and face to face
 -   3-6 Meetings per annum of 1-2 hours duration (dependent on agenda).
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/womens-commission/member.md
+++ b/_position_description/womens-commission/member.md
@@ -78,7 +78,7 @@ Annual activities and time commitment include the following.
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda
     and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/youth-and-children-commission/chair.md
+++ b/_position_description/youth-and-children-commission/chair.md
@@ -54,12 +54,12 @@ Annual activities and time commitment include the following:
 ### Commission meetings
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Meetings with the Sport Development Director
 
--   (Skype and face to face)
+-   Video conference and face to face
 -   3-6 Meetings per annum of 1-2 hours duration (dependent on agenda).
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships

--- a/_position_description/youth-and-children-commission/member.md
+++ b/_position_description/youth-and-children-commission/member.md
@@ -54,7 +54,7 @@ Annual activities and time commitment include the following:
 ### Commission meetings                                                                                                                              
 
 -   Commission Meetings are conducted on an as needs basis and vary in duration (dependant on agenda and/or issues).
--   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via Skype.
+-   Estimate 3-6 Commission Meetings per annum of 2-3 hours duration via video conference.
 -   Preparation time of 1-2 hours for each Commission meeting.
 
 ### Attendance at FIT World Cup Event and possible attendance at Regional Championships


### PR DESCRIPTION
While Skype is the predominant form of video communication the Federation has started using alternatives. As such we should not specify any particular vendor product when we can simply describe the class of communication tool.