### PR TITLE
Add "Fork me on GitHub" ribbon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,10 @@
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
+  <!--[if lt IE 9]>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />
+  <![endif]-->
   <style type="text/css">
     li { padding-left: 0.3em; }
     ol > li > ol { list-style-type: lower-alpha; }

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,3 +7,5 @@
   </div>
 
 </header>
+
+<a class="github-fork-ribbon" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/fork" title="Fork me on GitHub">Fork me on GitHub</a>


### PR DESCRIPTION
Using GitHub will allow us to easily encourage community translations and contributions to improve our documentation.

Adding this ribbon makes it easy for a visitor reading the page to create a fork. Still required are contribution guides – not yet written.