### PR TITLE
Coaching Commission Policy

### DIFF
--- a/_policy/coaching.md
+++ b/_policy/coaching.md
@@ -74,8 +74,6 @@ changes and/or additions to the above purposes.
 
 ## Membership of the Coaching Commission
 
-### Membership
-
 The Coaching Commission, appointed by the FIT Board under Rule 36, FIT Constitution 2011, shall
 consist of:
 
@@ -148,8 +146,6 @@ Sessions:
 
 ## Coaching Programs
 
-### Coaching Programs
-
 The policy applies to the following FIT Coaching Programs:
 
 -   FIT Introductory Coaching Course
@@ -161,8 +157,6 @@ Coaching Qualifications will be for 5 years.
 
 ## FIT Coaching Register
 
-### Register
-
 The Coaching Commission will work with NTAs to ensure that a register is maintained which details
 the following:
 
@@ -172,8 +166,6 @@ the following:
 -   FIT Coaching Presenters
 
 ## Submissions
-
-### Coaching Requests
 
 All coaching requests, proposals, etc for coaching education programs are to be submitted to the FIT
 Sport Development Director on the Sport Development Proposal/Request form for endorsement.

--- a/_policy/coaching.md
+++ b/_policy/coaching.md
@@ -1,15 +1,223 @@
 ---
-title: Coaching Commission Policies
-layout: default
+title: Coaching Commission Policy
 
-approval_authority: 
-responsible_officer: 
-first_approved: null
+approval_authority: President
+responsible_officer: Sport Development Director
+first_approved: 2016-09-01
 last_amended: null
 effective_date: null
-review_date: null
+review_date: 2017-10-01
 ---
 
-# FIT Coaching Commission Policies
+# FIT Coaching Commission Policy
 
-These policies are under review by the Coaching Commission and FIT Board.
+## Introduction
+
+### Background
+
+The Federation of International Touch (FIT) is the managing body for Touch globally and manages all
+aspects of the sport. One of the key areas of responsibilities for FIT is improve the ongoing
+development of all coaches. Education, safety and training, development, ethics and behaviour are
+essential components of the sport and are critical to effective progress of the sport. A set of
+policies are required to ensure that the coaching arm of the sport remains effective and in a
+positive state of regular development.
+
+### Aim
+
+The aim of this document is to detail the policy by which the coaching arm of Touch globally is
+managed within and under the guidelines of FIT.
+
+### Authority
+
+This Coaching Policy has been developed by the FIT Coaching Commission and is published with the
+approval and endorsement of the FIT Board.
+
+### Annual Policy Review
+
+This Coaching Commission Policy is a dynamic document. To ensure that it remains both current and
+applicable, the FIT Coaching Commission is to review the policy annually. All recommended amendments
+are to be submitted to the FIT Board for endorsement and approval.
+
+## Purpose of the Coaching Commission
+
+### Purpose
+
+The purpose of the Coaching Commission is to:
+
+1.  Provide global standards for:
+    -   Coaching education programs
+    -   Coaching competencies
+    -   Coaching assessments
+    -   Coaching performance and appointments
+2.  Make recommendations to the FIT Board regarding coaching development by and within Member
+    National Touch Associations (NTA).
+
+### Support of Region/Member NTAs
+
+Support the FIT approved Touch personnel in each Region/Member NTA to progress coaching within
+their Region/Member NTA by:
+
+-   Providing advice and mentoring by identifying and endorsed, suitably qualified and experienced
+    personnel
+-   Providing FIT endorsed coaching education programs through courses, seminars and other
+    activities
+-   Identifying and endorse suitably qualified and experienced personnel to help deliver coaching
+    education programs and development
+-   Developing FIT coach education resources
+-   Conducting surveys within member NTA’s to identify, enhance and develop global standards in
+    coaching
+-   Providing network opportunities for NTA’s to share ideas, experiences and initiatives for their
+    ongoing development
+
+The Coaching Commission may make recommendations to the FIT Board in relation to any potential
+changes and/or additions to the above purposes.
+
+## Membership of the Coaching Commission
+
+### Membership
+
+The Coaching Commission, appointed by the FIT Board under Rule 36, FIT Constitution 2011, shall
+consist of:
+
+-   Commissioner - Chair
+-   Commission Member - Maximum 10 (2 per Region)
+-   FIT Representative - FIT Sport Development Director
+
+## Appointment of Coaching Commission Chair and Members
+
+### Appointment Protocol
+
+The following details apply to the appointment of the Coaching Commission Chair and Members:
+
+The Coaching Commission Chair and Members shall be appointed from the date of appointment to one
+month after the next election of Board members at the World Cup (approximately four year cycle). In
+the event that the FIT Board does not appoint the FIT Coaching Commission Chair and Members prior to
+the expiry of their individual terms of appointment, the Chair and Members may continue in office
+past the expiry date of appointment to maintain continuity of service until the FIT Board makes new
+appointments.
+
+Appointments made during the four year cycle and between Annual General Meetings will conclude as
+per the timeframe detailed above.
+
+### Vacancy of FIT Coaching Commission Membership
+
+Circumstances in which the position of Chair or Coaching Commission member becomes vacant by virtue
+of:
+
+-   Dies
+-   Resigns
+-   Becomes an employee of the Federation
+
+A decision by the FIT Board and/or Coaching Commission Chair regarding termination as a result of:
+
+-   Has acted in a manner unbecoming or prejudicial to the objects and interest of the Federation
+    and/or Touch;
+-   Has brought the Federation into disrepute; and/or
+-   Has not carried out the duties and responsibilities as detailed in the relevant Role Description
+    of Chair or Coaching Commission Member, or as directed.
+
+The process for the Chair or member to submit a formal resignation is as follows:
+
+-   All resignations must be in writing.
+-   Resignation by the Chair must be to the FIT Board.
+-   Resignation by members must be to the Chair.
+-   The process for filling a vacancy must be in accordance with 4.1 Appointment Protocol.
+
+## Coaching Development
+
+### NTA Requests for Coaching Development
+
+NTA Members should apply to the FIT Coaching Commission for all levels and aspects of coaching
+development.
+
+### Criteria for Coaching Presenters
+
+To ensure that coaching development is delivered at a high standard the following criteria is set
+for coaching presenters required to deliver Coaching Programs, Education, Seminars and Field
+Sessions:
+
+-   Must possess a minimum accreditation and qualification as determined by the FIT Coaching
+    Certificate
+-   Must have the endorsement of the FIT Coaching Commission to undertake coaching education
+    programs, seminars and field sessions for NTA Members.
+-   Must complete and submit a Sport Development Proposal/Request form for Coaching Presenters to
+    the FIT Coaching Commission for endorsement prior to undertaking coaching education programs,
+    seminars and field sessions for NTA Members.
+-   Must submit a report detailing the outcomes of the delivered program, in accordance with the
+    Coaching Commission Development Request form.
+
+## Coaching Programs
+
+### Coaching Programs
+
+The policy applies to the following FIT Coaching Programs:
+
+-   FIT Introductory Coaching Course
+-   FIT Intermediate Coaching Course
+-   FIT Advanced Coaching Course
+-   FIT High Performance Coaching Course
+
+Coaching Qualifications will be for 5 years.
+
+## FIT Coaching Register
+
+### Register
+
+The Coaching Commission will work with NTAs to ensure that a register is maintained which details
+the following:
+
+-   FIT Intermediate Qualified Coaches
+-   FIT Advanced Qualified Coaches
+-   FIT High Performance Qualified Coaches
+-   FIT Coaching Presenters
+
+## Submissions
+
+### Coaching Requests
+
+All coaching requests, proposals, etc for coaching education programs are to be submitted to the FIT
+Sport Development Director on the Sport Development Proposal/Request form for endorsement.
+
+## Reporting
+
+### Changes to Coaching Commission Policy
+
+Changes to the Coaching Commission policy are to be submitted to the FIT Board through the Coaching
+Commission. Approval by the FIT Board will be required before any changes are initiated.
+
+### Reporting by the Commission to the FIT Board
+
+The Coaching Commission Chair will report as requested to the FIT Board Representative prior to the
+FIT Board meetings.
+
+The Coaching Commission Chair will ensure the Coaching Commission policy and activities align with
+the FIT Sports Development policy.
+
+The progress of the Coaching Commission will be a standard agenda item for the FIT Board governance
+skype meetings until determined otherwise.
+
+## Financial Operations
+
+### Remuneration of Commission Members
+
+Membership of the Coaching Commission is on a volunteer basis for which no fees or remuneration will
+be paid.
+
+### Commission Operating Expenses
+
+Authorised operating expenses of the Coaching Commission are to be met by the FIT and/or the
+relevant Member Country NTAs.
+
+No expenses will be paid by FIT unless the FIT Board gives prior written approval.
+
+## Authority and Approval
+
+### FIT Volunteers Authority
+
+Each Coaching Commission member and the Member Country NTA in which each member resides are required
+to complete and sign the FIT Volunteer Authority - Federation Commissions.
+
+The continued operation and membership of the Coaching Commission shall be reviewed annually by the
+FIT Board at or around the time of each Annual General Meeting.
+
+Further information is available on the FIT website.


### PR DESCRIPTION
This pull request adds the Coaching Commission Policy document that was
provided in Microsoft Word format by the Sport Development Director, Peter
Topp.

The first commit is a direct translation of the document to Markdown; in the
second commit I have removed some superfluous sub-headings.