### PR TITLE
Recognised Playing Divisions Policy

### DIFF
--- a/_policy/event-classification.md
+++ b/_policy/event-classification.md
@@ -12,4 +12,8 @@ review_date: null
 
 # FIT Event Classification Policy
 
-This policy is under review by the FIT Board.
+This policy is under review by the FIT Board -- the current version of this policy is available on
+the [Events](https://www.internationaltouch.org/events/) section of the [FIT website].
+
+
+[FIT website]: https://www.internationaltouch.org/

--- a/_policy/recognised-divisions.md
+++ b/_policy/recognised-divisions.md
@@ -50,7 +50,7 @@ and the "Over 30" age groups.
 
 Not all divisions will be contested at all events.
 
-Eligibility to compete in a recoginised division is defined by the [FIT Player Eligibility Policy].
+Eligibility to compete in a recognised division is defined by the [FIT Player Eligibility Policy].
 
 ## FIT recognised playing division policy
 

--- a/_policy/recognised-divisions.md
+++ b/_policy/recognised-divisions.md
@@ -1,0 +1,120 @@
+---
+title: Recognised Playing Divisions Policy
+
+approval_authority: Sport Development Officer
+responsible_officer: Event Commission Chair
+first_approved: 2016-09-06
+last_approved: null
+effective_date: null
+review_date: 2020-10-01
+---
+
+# FIT Recognised Playing Divisions Policy
+
+## Purpose of policy
+
+The purpose of this policy is to provide the definitive list of playing divisions which FIT
+recognises.  This policy gives clear direction to Member NTA's allowing them to engage in planning
+exchanges and is essential to in allowing FIT to produce world rankings.
+
+## Policy scope and application
+
+This policy applies to all Tier 1-5 events as identified by the [FIT Event Classification Policy].
+
+## Definitions
+
+Age group
+:   an upper or lower date of birth boundary used to distinguish eligibility
+
+Category
+:   a gender qualifier used to distinguish eligibility
+
+Division
+:   the combination of an age group or open age group with a category
+
+Open age group
+:   the absence of an upper or lower date of birth boundary
+
+Product
+:   the outcome of combining two factors
+
+## Regulatory background
+
+N/A
+
+## Policy statement
+
+The complete list of recognised playing divisions is the product of the recognised categories and
+the recognised age groups, with the exception of Mixed. Mixed is limited to the Open, all "Under"
+and the "Over 30" age groups.
+
+Not all divisions will be contested at all events.
+
+Eligibility to compete in a recoginised division is defined by the [FIT Player Eligibility Policy].
+
+## FIT recognised playing division policy
+
+### Recognised categories
+
+-   Mens (referred to as *Boys* during adolescence)
+-   Womens (referred to as *Girls* during adolescence)
+-   Mixed
+
+### Recognised age groups
+
+-   Open
+-   Under 15
+-   Under 18
+-   Under 21
+-   Over 30
+-   Over 35
+-   Over 40
+-   Over 45
+-   Over 50
+
+### Recognised divisions
+
+#### Open divisions
+
+-   Mens Open (MO)
+-   Womens Open (WO)
+-   Mixed Open (XO)
+
+#### Youth divisions
+
+-   Boys Under 15 (B15)
+-   Boys Under 18 (B18)
+-   Mens Under 21 (M21)
+-   Girls Under 15 (G15)
+-   Girls Under 18 (G18)
+-   Womens Under 21 (W21)
+-   Mixed Under 15 (X15)
+-   Mixed Under 18 (X18)
+-   Mixed Under 21 (X21)
+
+#### Senior divisions
+
+-   Mens Over 30 (M30)
+-   Mens Over 35 (M35)
+-   Mens Over 40 (M40)
+-   Mens Over 45 (M45)
+-   Mens Over 50 (M50)
+-   Womens Over 30 (W30)
+-   Womens Over 35 (W35)
+-   Womens Over 40 (W40)
+-   Womens Over 45 (W45)
+-   Womens Over 50 (W50)
+-   Mixed Over 30 (X30)
+
+## Contact
+
+Enquiries in relation to this policy should be directed to the [FIT Event Commission Chair].
+
+## Appendices
+
+Nil
+
+
+[FIT Event Commission Chair]: mailto:events@internationaltouch.org
+[FIT Event Classification Policy]: /policy/event-classification/
+[FIT Player Eligibility Policy]: /policy/player-eligibility/

--- a/_policy/recognised-divisions.md
+++ b/_policy/recognised-divisions.md
@@ -14,8 +14,8 @@ review_date: 2020-10-01
 ## Purpose of policy
 
 The purpose of this policy is to provide the definitive list of playing divisions which FIT
-recognises.  This policy gives clear direction to Member NTA's allowing them to engage in planning
-exchanges and is essential to in allowing FIT to produce world rankings.
+recognises. This policy gives clear direction to Member NTA's allowing them to engage in planning
+exchanges and is essential in allowing FIT to produce world rankings.
 
 ## Policy scope and application
 

--- a/_policy/recognised-divisions.md
+++ b/_policy/recognised-divisions.md
@@ -44,10 +44,6 @@ N/A
 
 ## Policy statement
 
-The complete list of recognised playing divisions is the product of the recognised categories and
-the recognised age groups, with the exception of Mixed. Mixed is limited to the Open, all "Under"
-and the "Over 30" age groups.
-
 Not all divisions will be contested at all events.
 
 Eligibility to compete in a recognised division is defined by the [FIT Player Eligibility Policy].

--- a/_policy/recognised-divisions.md
+++ b/_policy/recognised-divisions.md
@@ -65,7 +65,7 @@ Eligibility to compete in a recognised division is defined by the [FIT Player El
 -   Open
 -   Under 15
 -   Under 18
--   Under 21
+-   Under 20
 -   Over 30
 -   Over 35
 -   Over 40
@@ -84,13 +84,13 @@ Eligibility to compete in a recognised division is defined by the [FIT Player El
 
 -   Boys Under 15 (B15)
 -   Boys Under 18 (B18)
--   Mens Under 21 (M21)
+-   Mens Under 20 (M20)
 -   Girls Under 15 (G15)
 -   Girls Under 18 (G18)
--   Womens Under 21 (W21)
+-   Womens Under 20 (W20)
 -   Mixed Under 15 (X15)
 -   Mixed Under 18 (X18)
--   Mixed Under 21 (X21)
+-   Mixed Under 20 (X20)
 
 #### Senior divisions
 

--- a/_policy/recognised-divisions.md
+++ b/_policy/recognised-divisions.md
@@ -3,7 +3,7 @@ title: Recognised Playing Divisions Policy
 
 approval_authority: Sport Development Officer
 responsible_officer: Event Commission Chair
-first_approved: 2016-09-06
+first_approved: null
 last_approved: null
 effective_date: null
 review_date: 2020-10-01


### PR DESCRIPTION
On the 23rd August 2016 the board advised Member NTA's that FIT would be reverting to the W30 division following an analysis of the playing data for the last 4 years of the W27 division.

This policy is an anchor that explicitly identifies the playing divisions we will recognise; the policy will allow the Event Commission to further develop related policies, in particular World Rankings and Event Structure & Seeding.

I have nominally marked the *Sport Development Officer* as the approval authority, however please advise if this should be passed to the *Secretary General* or *President*.

Similarly it might be appropriate for the responsible officer to be the *Sport Development Officer* if not the *Event Commission Chair*.