### PR TITLE
Event Structure & Seeding Policy

### DIFF
--- a/_policy/event-structure-seeding.md
+++ b/_policy/event-structure-seeding.md
@@ -1,0 +1,106 @@
+---
+title: Event Structure & Seeding Policy
+
+approval_authority: Sport Development Director
+responsible_officer: Event Commission Chair
+first_approved: null
+last_amended: null
+effective_date: null
+review_date: 2020-10-01
+---
+
+# FIT Event Structure & Seeding Policy
+
+## Purpose of policy
+
+The purpose of this policy is to provide event managers and participants with a uniform process for
+determining event structure that removes ambiguity and subjectivity for all FIT events.
+
+## Policy scope and application
+
+This policy applies to all events classified as Tier 1-2 according to the [FIT Event Classification
+Policy].
+
+Tier 3 events are bilateral and **do not** require seeding or tournament constructs.
+
+Event managers responsible for delivering Tier 4-5 events are encouraged to adopt this policy in so
+far as it is applicable.
+
+## Definitions
+
+Age group
+:   an upper or lower date of birth boundary used to distinguish eligibility
+
+Category
+:   a gender qualifier used to distinguish eligibility
+
+Division
+:   the combination of an age group or open age group with a category
+
+Open age group
+:   the absence of an upper or lower date of birth boundary
+
+Round robin
+:   a tournament in which each competitor plays in turn against every other
+
+Seeding
+:   process of ordering teams based on prior performance in an attempt to equally distribute
+    strength across pools
+
+Serpent distribution
+:   the process of distributing seeded entities by *snaking* from left to right, down, right to
+    left, down, and continuing until all entities are expired.
+
+## Regulatory background
+
+N/A
+
+## Policy statement
+
+FIT is committed to ensuring all events provide the opportunity for the best teams to meet in the
+finale of every division.
+
+FIT events must have an operating environment where the use of preliminary pools is atypical.
+Competing constraints of event duration, available space, number of teams and player welfare
+considerations can occassionally encumber this goal. It is in such cases this policy provides the
+framework on how to proceed despite these impediments, in line with the FIT objective above.
+
+## FIT event structure & seeding policy
+
+### Structure
+
+It is always preferable that preliminary stages of an event are a round robin of cycle one. If time
+permits subsequent cycles may be included on the proviso that all cycles are complete.
+
+-   All events must use the [FIT Tournament Planner] tool to produce a model competition structure
+    for each division.
+-   The planning tool asks for the following input parameters to determine the model structure:
+    -   who are the teams, in seeding order?
+    -   how many days of competition are available, including the final series?
+    -   what is the daily *maximum* number of games a team may play?
+    -   what is the daily *minimum* number of games a team must play?
+-   If the planning tool determines that pools are required it will distribute the teams across the
+    number of pools using a serpent distribution.
+-   No variation to the pools or ordering of matches is to occur -- allowances for extraordinary
+    occurences have been factored into draws wherever possible
+    -   If one or more teams withdraw any time prior to the start of the competition the model draw
+        is to be reproduced using the remaining teams without adjusting any other variables
+
+### Seeding
+
+-   Seeding is to be determined by a team's world ranking 90 days prior to the event commencing
+-   The [FIT World Ranking Policy] details the method used to determine world rankings
+
+## Contact
+
+Enquiries in relation to this policy should be directed to the [FIT Event Commission Chair].
+
+## Appendices
+
+Nil
+
+
+[FIT Event Classification Policy]: /policy/event-classification/
+[FIT Event Commission Chair]: mailto:events@internationaltouch.org
+[FIT Tournament Planner]: https://www.internationaltouch.org/tournament-planner/
+[FIT World Ranking Policy]: /policy/world-ranking/


### PR DESCRIPTION
This policy outlines the guiding principles for setting up Federation event draws.

References the *Recognised Playing Divisions* policy which is the subject of pull request #6.