### PR TITLE
Add trailing slash so `jekyll` will produce index.html inside directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,10 +23,10 @@ markdown: kramdown
 collections:
   policy:
     output: true
-    permalink: /policy/:path
+    permalink: /policy/:path/
   position_description:
     output: true
-    permalink: /position/:path
+    permalink: /position/:path/
 
 defaults:
   - scope:

--- a/constitution.md
+++ b/constitution.md
@@ -9,7 +9,7 @@ last_amended: 2011-08-19
 effective_date: 2011-08-19
 review_date: null
 
-permalink: /constitution
+permalink: /constitution/
 ---
 
 # Constitution


### PR DESCRIPTION
While serving content up from GitHub Pages directly, this isn't required - it's doing a fine job for now. However in light of a desire to support multiple languages to be supported from a single code base we have to think about when we'll host this ourselves.

A very quick proof of concept using `docker` with the `nginx:alpine` container looks like this:

    # compile the static html output -- defaults to ./_site
    jekyll build

    # start an ephemeral nginx instance in the foreground on port 80
    docker run --rm -it \
        --publish 80:80 \
        --volume $(pwd)/_site:/usr/share/nginx/html \
        nginx:alpine

Ideally we would work this into a continuous delivery pipeline, but this is a good demonstration as to why the change is required.