### PR TITLE
Alter the seeding policy to reward semi-finalists from previous event

### DIFF
--- a/_policy/event-structure-seeding.md
+++ b/_policy/event-structure-seeding.md
@@ -89,6 +89,12 @@ permits subsequent cycles may be included on the proviso that all cycles are com
 ### Seeding
 
 -   Seeding is to be determined by a team's world ranking 90 days prior to the event commencing
+    -   When returning to an event the most recent gold, silver and bronze medalists, plus the
+        semi-finalist, will retain their finishing position and become the first, second, third and
+        fourth seeds, respectively, in place of their world ranking.
+    -   The remaining seeds are awarded based on world rankings where the nation has ranking points.
+    -   After all teams with world ranking points have been seeded remaining teams will be drawn in
+        a lottery.
 -   The [FIT World Ranking Policy] details the method used to determine world rankings
 
 ## Contact


### PR DESCRIPTION
While the World Ranking Policy is does a good job of dealing with regional changes to playing strength over time (particularly between World Cups) it can result in a relegation of teams who performed well but have simply not played since.

We don't want to revert to the former system where recent form is entirely ignored for 4 year old data, however we do want to assure nations that making it into the semi-finals is an excellent achievement and provide some longer term reward for that.

This amendment will bypass the ranking points for the top-4 finishers at an event and the fill in behind them based on ranking points.