### PR TITLE
Eligibility Recommendation - AGM 2019

### DIFF
--- a/_includes/head_legacy.html
+++ b/_includes/head_legacy.html
@@ -16,6 +16,7 @@
   <style type="text/css">
     li { padding-left: 0.3em; }
     ol > li > ol { list-style-type: lower-alpha; }
+    ol > li > p { margin-bottom: 0; }
     h2 + ol > li > ol { list-style-type: none; }
     dl > dt:before { clear: both; }
     dl > dt { font-weight: bold; float: left; }
@@ -46,6 +47,13 @@
     }
     ol li ol li ul li {
       list-style-type: disc;
+    }
+    ol li ol li ol li {
+      list-style: none;
+    }
+    ol li ol li ol li::before {
+      width: 2em;
+      margin-left: -4em;
     }
   </style>
   <style type="text/css" media="print">

--- a/_policy/player-eligibility.md
+++ b/_policy/player-eligibility.md
@@ -123,9 +123,14 @@ Represented
 
     Normally, individuals must satisfy only one of the above requirements. However, where satisfying
     paragraph 4.1.1 results in an individual being able to Represent multiple Members at the same
-    time, the individual must additionally satisfy either paragraph 4.1.2 or 4.1.3 before their
-    first Representation for that Member, after which time this additional requirement is not
-    necessary.
+    time, the individual must additionally satisfy:
+    -   their Place of Birth is in the territory for which the Member is recognized by the
+        Federation (e.g. Ireland); or
+    -   4.1.2; or
+    -   4.1.3
+
+    before their first Representation for that Member, after which time this additional requirement
+    is not necessary.
 2.  In addition to the above requirement at paragraph 4.1, to be eligible to Represent a Member in a
     Federation Event an individual must not have Represented another Member in a Federation Event
     during the previous three (3) International Seasons (which includes the periods of time between

--- a/_policy/player-eligibility.md
+++ b/_policy/player-eligibility.md
@@ -23,160 +23,202 @@ review_date: 2019-12-01
     individual and the represented country. The International Court of Arbitration for Sport (CAS)
     has ruled that Legal Nationality and Sporting Nationality may be "different", one defined in
     Public Law and the other in Private Law.
-3.  The Federation of International Touch (the Federation) therefore has the authority to decide
-    eligibility criteria for participants in the sport in the international arena as governed by the
-    Federation and Member Country National Touch Associations (NTA). Specific eligibility criteria
-    may differ from Legal Nationality and should be subject to any internationally endorsed anti
-    discrimination or equality policies. The focus of this Eligibility Policy is that the criteria
-    are both fair and equitable to most.
+3.  The Federation of International Touch therefore has the authority to decide eligibility criteria
+    for participants in the sport in the international arena as governed by the Federation and
+    Members. Specific eligibility criteria may differ from Legal Nationality and should be subject
+    to any internationally endorsed anti discrimination or equality policies. The focus of this
+    Eligibility Policy is that the criteria are both fair and equitable to most.
 4.  The Federation also agrees that the basis of International Sport should be just that, about
     individuals competing for their country against individuals from another country and any
-    competing national team should be a Member Country NTA representative national team.
+    competing national team should be a representative national team organized by the national
+    governing body of the relevant Member.
 
 ## Application
 
-1.  This policy applies to all Federation Events classified as Tier 1 to Tier 3 as defined in the
-    Classification of Events policy.
-2.  This policy applies to all participants of Member countries competing at any Federation Event.
-    Member countries are responsible to ensure all individuals representing that Member country meet
-    the eligibility criteria prior to participation at a Federation Event.
-3.  Member countries are encouraged to apply this policy to all events that are not afforded
-    Federation Event status.
-4.  This eligibility policy applies to representative players registered in national teams. The
-    policy does not apply to officials, coaches, referees, support staff or to representative
-    players under eighteen (18) years of age.
+1.  This policy applies to all Federation Events as defined below.
+2.  This policy applies to all players competing at any Federation Event. Members are responsible
+    for ensuring all individuals representing that Member meet the eligibility criteria prior to
+    participating at a Federation Event.
+3.  Members are encouraged to apply this policy to all events that are not afforded Federation Event
+    status.
+4.  This policy does not apply to officials, coaches, referees, or support staff.
 
 ## Definitions
 
-1.  **Birth Certificate:** A formal, statutory document recording the place, date and time of birth
-    of an individual. For the purposes of this policy a certified copy of a Birth Certificate or
-    "Birth Extract" is deemed to be a Birth Certificate.
-2.  **Citizenship:** A process whereby an immigrant individual achieves the requirements to satisfy
-    a country's criteria for being a legitimate national.
-3.  **Country:** A geographic region as defined by the 2008 FIT Constitution.
-4.  **Driving Licence:** A current, photographic, identification card issued by a government
-    department entitling an individual to drive in a specific country or region.
-5.  **Federation Event:** A tournament at which international competition occurs in accordance with
-    event classification contained in the Federation Event Classification Policy.
-6.  **International competition:** Competition between two or more Member National Touch
-    Associations.  The competing teams are national representative teams.
-7.  **International season:** The period from April 1 to July 31 each calendar year during which
-    period Tier 1-3 Federation Events may be scheduled.
-8.  **Legal National:** An individual player who has been formally recognised by the respective
-    government as a person of origin of a country, on the basis of birth, parentage, residency or
-    other legal criteria pertaining to that country.
-9.  **Member:** National Touch Associations affiliated with the Federation and they may be Full
-    Members, Associate Members or Federation Members as defined from time to time.
-10. **Open (division):** A playing division in which there are only gender qualifications.
-11. **Parent:** Either a biological (blood) parent or a legal guardian (adopted) of an individual.
-    For the purpose of this policy a step parent or foster parent is not considered a parent unless
-    they are the legal guardian of the player in question.
-12. **Passport:** An official document issued by a government department certifying nationality of a
-    country and used by an individual for international travel.
-13. **Place of Birth:** The location of birth as recorded on an individual's Birth Certificate.
-14. **Represented:** An individual listed on the player registration sheet for a Member country
-    participating in a Tier 1, Tier 2, or Tier 3 Federation Event is deemed to have represented that
-    country. "Representation" shall be interpreted accordingly.
-15. **Residency:** Continuous domicile in a country except for short periods of absence away from
-    the normal place of residence for holidays and the like. The normal, common use definition in
-    the order of "a few weeks but no longer than a few months" is to apply.
-16. **Senior (divisions):** Playing divisions that have minimum age eligibility criteria.
+Continuous Resident
+:   An individual who has maintained their domicile in one Country or territory except for short
+    periods of absence away from the normal place of residence for holidays, business travel or
+    similar short trips. When defining the permitted length of a period of absence, the guideline of
+    "a few weeks but no longer than a few months" is to apply.
+
+Country
+:   A geographic region as defined by the 2008 FIT Constitution.
+
+Driving License
+:   A current, photographic, identification card issued by a government department entitling an
+    individual to drive in a specific country or region.
+
+Federation
+:   The Federation of International Touch
+
+Federation Event
+:   A Touch tournament at which Tier 1, 2 or 3 competition occurs in accordance with event
+    classification contained in the Federation Event Classification Policy.
+
+International Season
+:   The period from April 1 to July 31 each calendar year during which period Federation Events may
+    be scheduled.
+
+Legal National
+:   An individual player who has been formally and permanently recognised by the respective
+    government as a person of origin of a Country, on the basis of any legal criteria pertaining to
+    that Country, whereby the individual's status is not dependent on residence within that Country.
+
+Member
+:   National Touch Associations affiliated with the Federation and they may be Full Members,
+    Associate Members or Federation Members as defined from time to time.
+
+Naturalised Citizen
+:   An individual player who has completed any required process set out by the government of a
+    Country to obtain rights equivalent to becoming a Legal National, including the requirement
+    where the individual's naturalized status is not dependent on residence within the relevant
+    Country.
+
+Parent
+:   Either a biological (blood) parent or a legal guardian (adopted) of an individual. For the
+    purpose of this policy a step parent or foster parent is not considered a parent unless they are
+    the legal guardian of the player in question.
+
+Passport
+:   An official document issued by a government department certifying the status of an individual in
+    respect of a Country and used by an individual for international travel.
+
+Place of Birth
+:   The location of birth as recorded on an individual's birth certificate (being the formal,
+    statutory document recording the place, date and time of birth of an individual). For the
+    purposes of this policy a certified copy of a birth certificate or "birth extract" is deemed to
+    be sufficient.
+
+Represented
+:   An individual listed on the player registration sheet for a Member participating in a Federation
+    Event is deemed to have represented that Member. "Represent", "Representing" and
+    "Representation" shall be interpreted accordingly.
 
 ## Eligibility Criteria
 
-1.  For an individual to be eligible to represent a Member country in international competition, the
-    individual must be able to prove:
-    1.  They are a Legal National (including Citizenship) of the Member country; or
-    2.  They have parent (mother or father) who was born in the Member country; or
-    3.  They have been a resident of the Member country for three (3) years.
-2.  In addition to the above requirement at paragraph 4.1, to be eligible to represent a Member
-    country in international competition an individual must not have Represented another Member
-    country in international competition in the sport during the previous three (3) international
-    seasons (which includes the periods of time between such international seasons).
-    -   For the avoidance of doubt, clause 4.2 shall never prevent an individual Representing a
-        Member country where an individual intends to Represent a Member country in a Tier 1 event
-        and where the individual's last Representation was the previous running of the same Tier 1
-        event.
+1.  For an individual to be eligible to Represent a Member country in Federation Event, the
+    individual must be able to prove that:
+    1.  They are a Legal National or Naturalised Citizen of the Country of the relevant Member; or
+    2.  They have a Parent whose Place of Birth was:
+        1.  in the Country, in the event that the Member is the only Member within the Country (e.g.
+            South Africa); or
+        2.  in the territory for which the Member is recognized by the Federation, in the event that
+            the Country contains multiple Members (e.g. the United Kingdom); or
+    3.  They have been a Continuous Resident of:
+        1.  the Country, in the event that the Member is the only Member within the Country (e.g.
+            South Africa); or
+        2.  the territory for which the Member is recognized by the Federation, in the event that
+            the Country contains multiple Members (e.g. the United Kingdom)
+        for the three years preceding the relevant Federation Event.
+
+    Normally, individuals must satisfy only one of the above requirements. However, where satisfying
+    paragraph 4.1.1 results in an individual being able to Represent multiple Members at the same
+    time, the individual must additionally satisfy either paragraph 4.1.2 or 4.1.3 before their
+    first Representation for that Member, after which time this additional requirement is not
+    necessary.
+2.  In addition to the above requirement at paragraph 4.1, to be eligible to Represent a Member in a
+    Federation Event an individual must not have Represented another Member in a Federation Event
+    during the previous three (3) International Seasons (which includes the periods of time between
+    such international seasons). For the avoidance of doubt, clause 4.2 shall never prevent an
+    individual Representing a Member where an individual intends to Represent a Member in a Tier 1
+    event and where the individual's last Representation was the previous running of the same Tier 1
+    event. This requirement is subject to the exception in paragraph 5.2.2.
 3.  In addition to the criteria listed in paragraphs 4.1 and 4.2 above, to be eligible to
     participate in Federation events, an individual must also meet:
-    1.  Membership and eligibility requirements of the Member National Touch Association including,
-        but not limited to, matters relating to registration, insurance and financial status; and
+    1.  Membership and eligibility requirements of the Member including, but not limited to, matters
+        relating to registration, insurance and financial status; and
     2.  Gender criteria (male / men's or female / women's); and
-    3.  Age criteria in Senior aged divisions. It is normal for age-related divisions to specify a
-        minimum age by the year of competition or a minimum year of birth. Tournament regulations
-        will specify the criteria;
-    4.  Solely in the event that the individual has previously Represented another Member country
-        and relies upon clauses 4.1.2 or 4.1.3 to satisfy the requirements of clause 4.1, the
-        following additional requirements must have been met during the two (2) years immediately
+    3.  Age criteria in relevant divisions. It is normal for "Senior" divisions to specify a minimum
+        age by the year of competition or a minimum year of birth. It is normal for "Youth"
+        divisions to specify a maximum age by the year of competition or a maximum year of birth.
+        Tournament regulations will specify the criteria; and
+    4.  Solely in the event that the individual has previously Represented another Member and relies
+        upon clauses 4.1.2 or 4.1.3 to satisfy the requirements of clause 4.1, the following
+        additional requirements must have been met during both of the (2) years immediately
         preceding the date of the individual's application for eligibility in respect of the new
-        Member country:
-        -   The individual must have competed in the national Touch championships (or equivalent
-            pinnacle representative event) of the Member country they intend to Represent; and
-        -   The individual must have been a registered and financial member of an affiliated Touch
-            club within the Member country they intend to Represent.
-    5.  The requirements of clause 4.3.4 may be waived by FIT, upon application by an individual, in
-        the event that the individual's failure to satisfy the requirements were outside of the
-        individual's control including, but not limited to, situations such as injury or
-        cancellation of events.
+        Member:
+        1.  The individual must have competed in the national Touch championships (or equivalent
+            pinnacle representative event) of the Member they intend to Represent; and
+        2.  The individual must have been a registered and financial member of an affiliated Touch
+            club within the Member they intend to Represent.
+    5.  The requirements of clause 4.3.4 may be waived by the Federation, upon application by an
+        individual, in the event that the individual's failure to satisfy the requirements were
+        outside of the individual's control including, but not limited to, situations such as injury
+        or cancellation of events.
 4.  An individual participating in any Federation Event must be able to clearly prove their identity
     by having available to present one of the following as required:
-    1.  Current driving licence; or
-    2.  Current passport; or
+    1.  Current Driving License; or
+    2.  Current Passport; or
     3.  Other, suitable photographic evidence.
-5.  The responsibility to prove eligibility rests with both the individual and with the Member
-    country. Participants whose eligibility may be perceived as questionable for a particular
-    Federation Event should ensure that adequate and appropriate justification is at hand.
+5.  The responsibility to prove eligibility rests with both the individual and with the Member.
+    Players whose eligibility may be perceived as questionable for a particular Federation Event
+    should ensure that adequate and appropriate justification is at hand.
 
 ## Multiple Representations
 
-1.  An individual who has represented a Member country in international competition may seek a
-    clearance to represent a different Member country provided that individual meets the eligibility
-    criteria listed in paragraph 4.1 to 4.3 above, for the different Member country.
+1.  An individual who has Represented a Member in a Federation Event may seek a clearance to
+    represent a different Member country provided that individual meets the eligibility criteria
+    listed in paragraph 4.1 to 4.3 above, for the different Member.
 2.  An individual is entitled to multiple changes provided that the following provisions are adhered
     to:
-    1.  For an individual to be granted their first and/or second change of Representation, they
-        must satisfy clauses:
-        -   4.1;
-        -   4.2;
-        -   4.3.1;
-        -   4.3.2;
-        -   4.3.3; and
-        -   4.3.4;
-    2.  For an individual to be granted their third or subsequent change of Representation, they
+    1.  For an individual aged 18 years or older at the time of their most recent previous
+        representation to be granted their first and/or second change of Representation, they must
+        satisfy clauses:
+        -   4.1; and
+        -   4.2; and
+        -   all elements of paragraph 4.3
+    2.	For an individual aged under 18 years at the time of their most recent previous
+        representation to be granted their first and/or second change of Representation, they must
+        satisfy clauses:
+        -   4.1; and
+    3. 	For an individual to be granted their third or subsequent change of Representation, they
         must:
-        -   Fulfil all the obligations listed in 5.2.1; and
-        -   Satisfy FIT (exercising its sole discretion) that the change in Representation is
-            required due to an extraordinary set of circumstances resulting in the change of
-            Representation being in the best interests of the sport of Touch and which maintains the
-            integrity of fair sporting competition and the reputation of FIT and the sport of Touch.
+        -   Fulfil all the obligations listed in 5.2.1 or 5.2.2 (as applicable); and
+        -   Satisfy the Federation (exercising its sole discretion) that the change in
+            Representation is required due to an extraordinary set of circumstances resulting in the
+            change of Representation being in the best interests of the sport of Touch and which
+            maintains the integrity of fair sporting competition and the reputation of the
+            Federation and the sport of Touch.
 3.  Consideration of the circumstances of any request for a change should be applied and may include
     reasons of immigration, marriage, employment, development of the sport and personal matters.
 4.  The following clearance procedures applies should an individual wish to change intended
-    representation to a new Member country:
+    representation to a new Member:
     1.  An individual initially must apply for clearance by completing the
         [Clearance Application Form](https://goo.gl/forms/8CwQ26Sj2kc00F412) online, together with
         any supporting documentation not less than four (4) months prior to the respective
         Federation Event.
-    2.  The Federation Secretary General will then seek written comment from the individual's
-        current Member Country NTA followed by the individual's intended Member Country NTA.
+    2.  The Federation Secretary General will then seek written comment from the national governing
+        body of the individual's current Member followed by the national governing body of the
+        individual's intended new Member.
     3.  Following consideration of the matter the Federation Secretary General will advise the
-        individual and both Member Country NTA of the decision in writing.
+        individual and the national governing bodies of both relevant Members of the decision in
+        writing.
     4.  The Secretary General is to maintain a record of all clearance application requests and
         associated decisions.
     5.  An individual may appeal the decision of the Secretary General to the Federation Board in
         accordance with the Federation Judiciary Policy. The Board may appoint a Federation Appeals
         Panel to determine the appeal on its behalf. Any such appeal must be lodged with the
         Secretary General within 7 days of notification of the decision.
-    6.  Solely where a decision is made by FIT in accordance with clause 5.2.2, the details of such
-        decision shall be published by FIT into the public domain to ensure the transparency of
-        decision making is maintained.
+    6.  Solely where a decision is made by the Federation in accordance with clause 5.2.3, the
+        details of such decision shall be published by the Federation into the public domain to
+        ensure the transparency of decision making is maintained.
 
 ## Sanctions for Policy Breaches
 
-1.  Should a Member country be alleged to have allowed an ineligible individual to represent that
-    Member country and participate in any match during any Federation Event and eligibility is not
-    proven by the individual the Federation may take appropriate action. Penalties that may be
-    imposed include, but are not limited to the following:
+1.  Should a Member be alleged to have allowed an ineligible individual to represent that Member and
+    participate in any match during any Federation Event and eligibility is not proven by the
+    individual the Federation (or any individual or committee appointed by the Federation) may take
+    appropriate action. Penalties that may be imposed include, but are not limited to the following:
     1.  Deduction of competition points; and / or
     2.  Monetary fines; and / or
     3.  Banning of individuals from competitions or remaining matches; and / or
@@ -185,20 +227,20 @@ review_date: 2019-12-01
 
 ## Protests and Appeals
 
-1.  A Member country may protest to the Secretary General or to his or her appointee, or to any
-    Tournament Judiciary to consider such matters, about an individual either intending to represent
-    or who is representing or has represented another Member country at a Federation Event. Any
-    eligibility protest must relate to the eligibility criteria detailed at paragraphs 4.1 to 4.3.
-    Further details will normally be included in Event Rules and Regulation documents.
+1.  A Member may protest to the Secretary General or to his or her appointee, or to any Tournament
+    Judiciary to consider such matters, about an individual either intending to Represent or who is
+    Representing or has Represented another Member country at a Federation Event. Any eligibility
+    protest must relate to the eligibility criteria detailed at paragraphs 4.1 to 4.3.  Further
+    details will normally be included in Event Rules and Regulation documents.
 2.  Any eligibility protest must be submitted using the Player Eligibility Protest Form distributed
     in the event information package and must be submitted within thirty (30) minutes of completion
     of the game in which the alleged transgression occurred. The protest circumstances are to be
     clearly advised and available evidence supplied at the time of submission.
 3.  The Secretary General or appointee, through the respective Tournament Judiciary will consider
-    the matter and will advise all associated Member countries and the individual concerned of the
-    decision without delay.
-4.  The complainant Member country may appeal the Secretary General decision to the Federation Board
-    to determine an appeal in accordance with the Federation Judiciary Policy.
+    the matter and will advise all associated Members and the individual concerned of the decision
+    without delay.
+4.  The complainant Member may appeal the Secretary General decision to the Federation Board to
+    determine an appeal in accordance with the Federation Judiciary Policy.
 5.  Any matter of interpretation, or matter not provided for in this Policy, will be determined by
     the Federation Board.
 
@@ -206,8 +248,8 @@ review_date: 2019-12-01
 
 1.  This policy was approved by the Federation Board on 18th April 2018.
 2.  This policy, and any subsequent amendment of this policy, will take effect immediately upon
-    communication of same to Member countries through the FIT Digital Identity mailbox.
-3.  Member countries are responsible for the appropriate application of this policy.
+    communication of same to Members through the FIT Digital Identity mailbox.
+3.  Members are responsible for the appropriate application of this policy.
 4.  The policy is due for review in December 2019.
 
 ## Index of Decisions


### PR DESCRIPTION
These changes are being proposed to clarify a couple of contentious issues in the existing policy.

The two major issues being:

U18 exemption
-------------
This revision removes the blanket exclusion that prevents the policy from being applied to players under the age of 18.

The original intention of the exemption is to protect minors from being bound to a decision made prior to adulthood and possibly outside of their control.

It was never intended to permit youth players to represent a Member without firstly meeting the eligibility criteria.

This revision protects the original intent (a player may freely choose who they will Represent once they have turned 18) however they must at all times be eligible for the Member they are Representing.

Nationality across borders
--------------------------
Some nationalities span multiple countries. For example British Citizenship covers England, Scotland, Wales, Jersey, Guernsey and some of Ireland.

This revision clarifies how the policy is to apply to a player who is a Legal National or Naturalised Citizen in this situation.